### PR TITLE
refactor: runtime config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,13 +69,17 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
-    discordUserId: process.env.NUXT_DISCORD_USER_ID,
-    discordId: process.env.NUXT_DISCORD_ID,
-    discordToken: process.env.NUXT_DISCORD_TOKEN,
-    wakatimeUserId: process.env.NUXT_WAKATIME_USER_UD,
-    wakatimeCodig: process.env.NUXT_WAKATIME_CODING,
-    wakatimeEditors: process.env.NUXT_WAKATIME_EDITORS,
-    wakatimeLanguages: process.env.NUXT_WAKATIME_LANGUAGES,
-    wakatimeOs: process.env.NUXT_WAKATIME_OS
-  }
+    discord: {
+      userId: "",
+      id: "",
+      token: "",
+    },
+    wakatime: {
+      userId: "",
+      coding: "",
+      editors: "",
+      languages: "",
+      os: "",
+    },
+  },
 })

--- a/server/api/activity.get.ts
+++ b/server/api/activity.get.ts
@@ -1,4 +1,4 @@
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig(event)
-  return await $fetch(`https://api.lanyard.rest/v1/users/${config.discordUserId}`)
+  const { discord } = useRuntimeConfig(event)
+  return await $fetch(`https://api.lanyard.rest/v1/users/${discord.userId}`)
 })

--- a/server/api/stats.get.ts
+++ b/server/api/stats.get.ts
@@ -1,9 +1,11 @@
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig(event)
-  const coding = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeCodig}.json`)
-  const editors = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeEditors}.json`)
-  const os = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeOs}.json`)
-  const languages = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeLanguages}.json`)
+  const { wakatime } = useRuntimeConfig(event)
+
+  const coding = await $fetch(`https://wakatime.com/share/${wakatime.userId}/${wakatime.coding}.json`)
+  const editors = await $fetch(`https://wakatime.com/share/${wakatime.userId}/${wakatime.editors}.json`)
+  const os = await $fetch(`https://wakatime.com/share/${wakatime.userId}/${wakatime.os}.json`)
+  const languages = await $fetch(`https://wakatime.com/share/${wakatime.userId}/${wakatime.languages}.json`)
+
   return {
     coding,
     editors,


### PR DESCRIPTION
**Because of some typos, you will have to update your environment variables in your deployment like the USER_UD instead of the USER_ID**

Hello 👋,

I refactor the usage of the runtime config. First, there was some typos between the name of the environment variable and the name of the runtime config. Then, I remove the usage of `process.env` since Nuxt is already able to overwrite the runtime config with the environment variables.

You can learn more with this video: https://youtu.be/_FYV5WfiWvs?si=XWUumfMOBC90TivF

I think the runtime config `discord.id` and `discord.token` is not used and could be removed.
