### PR TITLE
fix: speed up stats

### DIFF
--- a/server/api/stats.get.ts
+++ b/server/api/stats.get.ts
@@ -1,13 +1,57 @@
+import { H3Event } from 'h3'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig(event)
-  const coding = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeCodig}.json`)
-  const editors = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeEditors}.json`)
-  const os = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeOs}.json`)
-  const languages = await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeLanguages}.json`)
+  const [coding, editors, os, languages] = await Promise.all([
+    cachedWakatimeCoding(event),
+    cachedWakatimeEditors(event),
+    cachedWakatimeOs(event),
+    cachedWakatimeLanguages(event)
+  ])
+
   return {
     coding,
     editors,
     os,
     languages
   }
+})
+
+const cachedWakatimeCoding = defineCachedFunction(async (event: H3Event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeCodig}.json`)
+}, {
+  maxAge: 24 * 60 * 60, // Wakatime does not update there data more than once a day
+  name: 'wakatime',
+  getKey: () => 'coding'
+})
+
+const cachedWakatimeEditors = defineCachedFunction(async (event: H3Event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeEditors}.json`)
+}, {
+  maxAge: 24 * 60 * 60, // Wakatime does not update there data more than once a day
+  name: 'wakatime',
+  getKey: () => 'editors'
+})
+
+const cachedWakatimeOs = defineCachedFunction(async (event: H3Event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeOs}.json`)
+}, {
+  maxAge: 24 * 60 * 60, // Wakatime does not update there data more than once a day
+  name: 'wakatime',
+  getKey: () => 'os'
+})
+
+const cachedWakatimeLanguages = defineCachedFunction(async (event: H3Event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch(`https://wakatime.com/share/${config.wakatimeUserId}/${config.wakatimeLanguages}.json`)
+}, {
+  maxAge: 24 * 60 * 60, // Wakatime does not update there data more than once a day
+  name: 'wakatime',
+  getKey: () => 'languages'
 })


### PR DESCRIPTION
Hello 👋,

I update the `stats` endpoint to use some cache and to parallelize the requests. This should make the endpoint significantly faster.

You can learn more about cached function with this link: https://nitro.unjs.io/guide/cache#edge-workers
