### PR TITLE
update incorrect nuxt studio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - **Framework** → [Nuxt.js](https://nuxtjs.org/)
 - **Content** → [Nuxt Content](https://content.nuxtjs.org/)
 - **Design System** → [NuxtUI](https://nuxtui.com/)
-- **CMS & Editing** → [Nuxt Studio](https://studio.nuxtjs.org/)
+- **CMS & Editing** → [Nuxt Studio](https://nuxt.studio)
 - **Langage** → [Typescript](https://www.typescriptlang.org/)
 - **Deployment** → [NuxtHub](https://hub.nuxt.com/)
 - **Styling** → [Sass](https://sass-lang.com/) & [Tailwind CSS](https://tailwindcss.com/)


### PR DESCRIPTION
Hello 👋,

* The PR updates Nuxt studio link from [https://studio.nuxtjs.org/](https://studio.nuxtjs.org/) to [https://nuxt.studio](https://nuxt.studio)