### PR TITLE
Improve project page SEO metadata

### DIFF
--- a/app/error.vue
+++ b/app/error.vue
@@ -1,3 +1,10 @@
+<script lang="ts" setup>
+useSeoMeta({
+  title: '404 - Page Not Found',
+  robots: 'noindex, nofollow'
+})
+</script>
+
 <template>
   <UApp class="relative flex h-screen flex-col items-center justify-center">
     <div class="flex flex-col items-center justify-center min-h-screen">

--- a/app/pages/projects/[slug].vue
+++ b/app/pages/projects/[slug].vue
@@ -21,14 +21,40 @@ const projectWithBody = computed(() => {
   }
 })
 
+const title = project.value.title
+const description = project.value.description
+
+const [ogImageUrl] = defineOgImage('Pergel.satori', {
+  title,
+  description,
+  headline: 'Arthur Danjou\u2019s Projects'
+})
+
 useSeoMeta({
-  title: project.value.title,
-  description: project.value.description,
-  ogTitle: `${project.value.title} • Arthur Danjou`,
-  ogDescription: project.value.description,
+  title,
+  description,
+  ogTitle: `${title} • Arthur Danjou`,
+  ogDescription: description,
   twitterCard: 'summary_large_image',
-  twitterTitle: project.value.title,
-  twitterDescription: project.value.description
+  twitterTitle: title,
+  twitterDescription: description
+})
+
+useSchemaOrg([
+  defineArticle({
+    headline: title,
+    description,
+    datePublished: project.value.publishedAt,
+    image: ogImageUrl
+  })
+])
+
+useBreadcrumbItems({
+  items: [
+    { label: 'Home', to: '/' },
+    { label: 'Projects', to: '/projects' },
+    { label: title, to: `/projects/${slug}` }
+  ]
 })
 
 const formattedDate = computed(() => {

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@vueuse/nuxt": "14.4.0",
         "baseline-browser-mapping": "^2.11.9",
         "eslint": "10.8.0",
-        "typescript": "~5.8.0",
+        "typescript": "~5.8.3",
         "vue-tsc": "3.3.9",
         "wrangler": "4.118.0",
       },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -169,7 +169,14 @@ export default defineNuxtConfig({
   },
 
   ogImage: {
-    buildCache: true
+    buildCache: true,
+    security: {
+      renderTimeout: 60000
+    }
+  },
+
+  robots: {
+    disallow: ['/api', '/studio']
   },
 
   schemaOrg: {


### PR DESCRIPTION
## Summary

- Add Open Graph and Twitter images to project pages via `defineOgImage`
- Add Schema.org Article structured data with `defineArticle` on project pages
- Add breadcrumb items to project pages
- Set the 404 error page SEO meta (`noindex, nofollow` and a proper title)
- Disallow `/api` and `/studio` in robots config
- Increase the OG image render timeout to 60s to avoid timeouts
- Bump TypeScript patch version to `~5.8.3`

## Testing

- Build passes with `bun run build`
- Inspect a project page's rendered HTML: `og:image`, `twitter:image`, and JSON-LD `Article` markup are present
- Inspect the 404 page: `<title>404 - Page Not Found</title>` and `noindex, nofollow` robots meta are present
- Check `/api` and `/studio` return `noindex` / disallow directives
- Verify breadcrumbs render on a project page
- Not run: live deployment and social-sharing preview checks