### PR TITLE
Add Now Playing music card with artwork proxy

### DIFF
--- a/app/components/home/live/LiveTelemetry.vue
+++ b/app/components/home/live/LiveTelemetry.vue
@@ -14,12 +14,14 @@
 
   <div class="flex flex-col lg:flex-row gap-4 mb-4">
     <div class="flex-1 min-w-0">
-      <HomeLiveStatusPage />
+      <HomeLiveNowPlaying class="h-full" />
     </div>
     <div class="flex-1 min-w-0">
       <HomeLiveActivity class="h-full" />
     </div>
   </div>
 
-  <HomeLiveStats />
+  <HomeLiveStatusPage class="mb-4" />
+
+  <HomeLiveStats class="mt-4" />
 </template>

--- a/app/components/home/live/NowPlaying.vue
+++ b/app/components/home/live/NowPlaying.vue
@@ -1,0 +1,149 @@
+<script lang="ts" setup>
+import type { HAMediaResponse } from '~~/types'
+
+const { data, refresh, pending } = useFetch<HAMediaResponse>('/api/ha/media', {
+  server: false,
+  lazy: true
+})
+useIntervalFn(refresh, 15_000)
+
+const nowPlaying = computed(() => data.value?.nowPlaying ?? null)
+const isPlaying = computed(() => !!nowPlaying.value)
+
+const statusLabel = computed(() => isPlaying.value ? 'Now Playing' : 'Idle')
+
+const hoverRingClass = computed(() => ({
+  'hover:ring-pink-500/50': isPlaying.value,
+  'hover:ring-neutral-500/30': !isPlaying.value
+}))
+
+const hasArtwork = computed(() => !!nowPlaying.value?.artwork)
+</script>
+
+<template>
+  <ClientOnly>
+    <UCard
+      v-if="data"
+      class="h-full flex flex-col transition-all duration-200 hover:ring-2"
+      :class="hoverRingClass"
+    >
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <div class="relative flex h-3 w-3">
+            <span
+              v-if="isPlaying"
+              class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-pink-400"
+            />
+            <span
+              class="relative inline-flex rounded-full h-3 w-3 transition-colors duration-300"
+              :class="isPlaying ? 'bg-pink-500' : 'bg-neutral-400'"
+            />
+          </div>
+          <span class="text-xs font-bold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+            {{ statusLabel }}
+          </span>
+        </div>
+        <div class="p-2 rounded-lg bg-pink-50 dark:bg-pink-900/30 text-pink-500 flex items-center justify-center">
+          <UIcon
+            name="i-ph-music-notes-duotone"
+            class="w-6 h-6 opacity-80"
+          />
+        </div>
+      </div>
+
+      <!-- Playing state -->
+      <div
+        v-if="nowPlaying"
+        class="flex gap-4 mt-3 pl-6 border-l-2 border-pink-100 dark:border-pink-900/30 ml-1.5"
+      >
+        <div class="shrink-0">
+          <img
+            v-if="hasArtwork"
+            :src="nowPlaying.artwork!"
+            :alt="nowPlaying.title ?? 'cover'"
+            class="w-20 h-20 rounded-lg object-cover shadow-sm bg-neutral-100 dark:bg-neutral-800"
+            loading="lazy"
+            @error="(e) => ((e.target as HTMLImageElement).style.display = 'none')"
+          >
+          <div
+            v-else
+            class="w-20 h-20 rounded-lg bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center"
+          >
+            <UIcon
+              name="i-ph-vinyl-record-duotone"
+              class="w-10 h-10 text-neutral-400"
+            />
+          </div>
+        </div>
+
+        <div class="flex-1 min-w-0 flex flex-col justify-center">
+          <h3 class="font-semibold text-neutral-900 dark:text-white truncate text-sm leading-tight">
+            {{ nowPlaying.title }}
+          </h3>
+          <p class="text-sm text-neutral-500 dark:text-neutral-400 truncate">
+            {{ nowPlaying.artist ?? 'Artiste inconnu' }}
+          </p>
+          <p
+            v-if="nowPlaying.album"
+            class="text-xs text-neutral-400 dark:text-neutral-500 truncate mt-0.5"
+          >
+            {{ nowPlaying.album }}
+          </p>
+          <div class="flex items-center gap-1.5 mt-1.5 text-xs text-neutral-400">
+            <UIcon
+              name="i-ph-speaker-high-duotone"
+              class="w-3.5 h-3.5 shrink-0"
+            />
+            <span class="truncate">{{ nowPlaying.friendly_name }}</span>
+            <span
+              v-if="nowPlaying.source"
+              class="hidden sm:inline truncate"
+            >• {{ nowPlaying.source }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Idle state -->
+      <div
+        v-else
+        class="text-sm text-neutral-500 dark:text-neutral-400 flex items-center gap-2 pl-6 border-l-2 border-neutral-200 dark:border-neutral-800 ml-1.5 mt-3"
+      >
+        <UIcon
+          name="i-ph-pause-circle-duotone"
+          class="w-4 h-4 shrink-0"
+        />
+        <p>Aucune musique en cours.</p>
+      </div>
+    </UCard>
+
+    <UCard v-else-if="pending">
+      <div class="flex items-center gap-3">
+        <USkeleton class="h-3 w-3 rounded-full" />
+        <div class="space-y-2 flex-1">
+          <USkeleton class="h-4 w-1/3" />
+          <USkeleton class="h-3 w-2/3" />
+        </div>
+      </div>
+      <div class="flex gap-4 mt-4">
+        <USkeleton class="w-20 h-20 rounded-lg" />
+        <div class="space-y-2 flex-1">
+          <USkeleton class="h-4 w-3/4" />
+          <USkeleton class="h-3 w-1/2" />
+          <USkeleton class="h-3 w-1/3" />
+        </div>
+      </div>
+    </UCard>
+
+    <template #fallback>
+      <UCard>
+        <div class="flex items-center gap-3">
+          <USkeleton class="h-3 w-3 rounded-full" />
+          <div class="space-y-2 flex-1">
+            <USkeleton class="h-4 w-1/3" />
+            <USkeleton class="h-3 w-2/3" />
+          </div>
+        </div>
+      </UCard>
+    </template>
+  </ClientOnly>
+</template>

--- a/app/components/home/live/StatusPage.vue
+++ b/app/components/home/live/StatusPage.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
-const { data, status, error } = useFetch('/api/ha/monitors', {
+const { data, status, error, refresh } = useFetch('/api/ha/monitors', {
   server: false,
   lazy: true
 })
+useIntervalFn(refresh, 60_000)
 
 const isLoading = computed(() => status.value === 'pending' || status.value === 'idle')
 const hasNoData = computed(

--- a/server/api/ha/media-cover.get.ts
+++ b/server/api/ha/media-cover.get.ts
@@ -1,0 +1,41 @@
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+  if (!config.ha.url || !config.ha.token) {
+    throw createError({ statusCode: 503, message: 'HA not configured' })
+  }
+
+  const query = getQuery(event)
+  const entityId = typeof query.entity_id === 'string' ? query.entity_id : null
+  if (!entityId || !entityId.startsWith('media_player.')) {
+    throw createError({ statusCode: 400, message: 'Invalid entity_id' })
+  }
+
+  const headers = { Authorization: `Bearer ${config.ha.token}` }
+  const base = config.ha.url.replace(/\/$/, '')
+
+  // Fetch entity to get fresh entity_picture path
+  const state = await $fetch<{ attributes: Record<string, unknown> }>(
+    `${base}/api/states/${entityId}`,
+    { headers }
+  ).catch(() => null)
+
+  const pic = state?.attributes?.entity_picture
+  if (typeof pic !== 'string' || !pic) {
+    throw createError({ statusCode: 404, message: 'No artwork' })
+  }
+
+  // HA returns relative path like /api/media_player_proxy/...
+  const url = pic.startsWith('http') ? pic : `${base}${pic}`
+
+  // Proxy the image with auth
+  const res = await fetch(url, { headers })
+  if (!res.ok || !res.body) {
+    throw createError({ statusCode: res.status || 404, message: 'Artwork fetch failed' })
+  }
+
+  const contentType = res.headers.get('content-type') || 'image/jpeg'
+  setHeader(event, 'content-type', contentType)
+  setHeader(event, 'cache-control', 'public, max-age=60, stale-while-revalidate=30')
+  // Allow frontend to cache aggressively
+  return sendStream(event, res.body as unknown as ReadableStream)
+})

--- a/server/api/ha/media.get.ts
+++ b/server/api/ha/media.get.ts
@@ -1,34 +1,84 @@
+interface HaState {
+  entity_id: string
+  state: string
+  attributes: Record<string, unknown>
+}
+
+function toStringOrNull(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() ? v.trim() : null
+}
+
 export default defineCachedEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
   if (!config.ha.url || !config.ha.token) {
-    return null
+    return { updatedAt: new Date().toISOString(), players: [], nowPlaying: null }
   }
 
   const headers = { Authorization: `Bearer ${config.ha.token}` }
-  const entityIds = [
-    'media_player.sonos_tv',
-    'media_player.ma_sonos',
-    'media_player.apple_tv_arthur',
-    'media_player.panasonic_tv',
-    'media_player.playstation_5',
-    'media_player.lecteurs_multi_media'
-  ]
+  const base = config.ha.url.replace(/\/$/, '')
 
-  const results = await Promise.allSettled(
-    entityIds.map(id =>
-      $fetch(`${config.ha.url}/api/states/${id}`, { headers })
-        .then(r => ({ entity_id: id, state: r.state, attributes: r.attributes }))
-        .catch(() => null)
-    )
-  )
-
-  const players = []
-  for (const r of results) {
-    if (r.status === 'fulfilled' && r.value) players.push(r.value)
+  let states: HaState[]
+  try {
+    states = await $fetch<HaState[]>(`${base}/api/states`, { headers, timeout: 5000 })
+  }
+  catch {
+    return { updatedAt: new Date().toISOString(), players: [], nowPlaying: null }
   }
 
-  return { updatedAt: new Date().toISOString(), players }
+  const mediaStates = states.filter(s => s.entity_id.startsWith('media_player.'))
+
+  const players = mediaStates.map((s) => {
+    const a = s.attributes
+    const rawArtwork = toStringOrNull(a.entity_picture)
+    // Keep raw path; frontend will use proxy endpoint for auth.
+    // Also provide absolute fallback for public HA.
+    let artwork: string | null = null
+    if (rawArtwork) {
+      if (rawArtwork.startsWith('http')) artwork = rawArtwork
+      else if (rawArtwork.startsWith('/')) artwork = `/api/ha/media-cover?entity_id=${encodeURIComponent(s.entity_id)}`
+      else artwork = rawArtwork
+    }
+
+    return {
+      entity_id: s.entity_id,
+      state: s.state,
+      friendly_name: toStringOrNull(a.friendly_name) ?? s.entity_id,
+      title: toStringOrNull(a.media_title),
+      artist: toStringOrNull(a.media_artist),
+      album: toStringOrNull(a.media_album_name),
+      artwork,
+      content_type: toStringOrNull(a.media_content_type),
+      app_name: toStringOrNull(a.app_name),
+      source: toStringOrNull(a.source)
+    }
+  })
+
+  // Prioritise Music Assistant players that are playing with a title
+  const isMA = (p: typeof players[number]) =>
+    p.app_name?.toLowerCase().includes('music assistant')
+    || p.entity_id.toLowerCase().includes('mass')
+    || p.entity_id.toLowerCase().includes('music_assistant')
+
+  const playing = players.filter(p => p.state === 'playing' && p.title)
+
+  let nowPlaying: typeof players[number] | null = null
+  if (playing.length) {
+    const maPlaying = playing.filter(isMA)
+    nowPlaying = (maPlaying.length ? maPlaying[0] : playing[0]) ?? null
+  }
+
+  // If nothing playing but something paused with metadata, keep null (idle handled in UI)
+  // Return also non-playing players for debugging, but limit to those with some metadata or active
+  const relevantPlayers = players.filter(p =>
+    p.state === 'playing' || p.state === 'paused' || p.title || isMA(p)
+  )
+
+  return {
+    updatedAt: new Date().toISOString(),
+    players: relevantPlayers,
+    nowPlaying
+  }
 }, {
-  maxAge: 30,
+  maxAge: 15,
   name: 'ha-media'
 })

--- a/types/index.ts
+++ b/types/index.ts
@@ -148,3 +148,22 @@ export interface StatsCard {
   icon: string
   color: string
 }
+
+export interface HAMediaPlayer {
+  entity_id: string
+  state: string
+  friendly_name: string
+  title: string | null
+  artist: string | null
+  album: string | null
+  artwork: string | null
+  content_type: string | null
+  app_name: string | null
+  source: string | null
+}
+
+export interface HAMediaResponse {
+  updatedAt: string
+  players: HAMediaPlayer[]
+  nowPlaying: HAMediaPlayer | null
+}


### PR DESCRIPTION
## Summary
- Added `NowPlaying.vue` card with playing, idle, and skeleton states, polling `/api/ha/media` every 15s and displaying title, artist, album, source and artwork
- Added `GET /api/ha/media-cover` proxy to fetch Home Assistant `entity_picture` with bearer auth and `public, max-age=60` caching
- Reworked `GET /api/ha/media` to fetch all `media_player.*` states at once, normalize fields via `toStringOrNull`, map artwork to proxy URL, and prioritize Music Assistant (`mass`/`music_assistant`/`app_name`) for `nowPlaying` selection with reduced cache `maxAge` of 15s
- Updated `LiveTelemetry.vue` layout to show `NowPlaying` alongside `Activity` and moved `StatusPage` below with 60s auto-refresh
- Added `HAMediaPlayer` and `HAMediaResponse` types in `types/index.ts`

## Testing
- Not run: automated tests for `media.get.ts` and `media-cover.get.ts`
- Not run: component rendering verification for playing / idle / pending skeletons in `NowPlaying.vue`
- Manual verification required: artwork proxy returns correct `content-type` and 404 when no artwork, and falls back to vinyl placeholder
- Manual verification required: `nowPlaying` prioritization when multiple `playing` players exist and idle message when none playing