### PR TITLE
Translate NowPlaying fallbacks to English

### DIFF
--- a/app/components/home/live/NowPlaying.vue
+++ b/app/components/home/live/NowPlaying.vue
@@ -81,7 +81,7 @@ const hasArtwork = computed(() => !!nowPlaying.value?.artwork)
             {{ nowPlaying.title }}
           </h3>
           <p class="text-sm text-neutral-500 dark:text-neutral-400 truncate">
-            {{ nowPlaying.artist ?? 'Artiste inconnu' }}
+            {{ nowPlaying.artist ?? 'Unknown artist' }}
           </p>
           <p
             v-if="nowPlaying.album"
@@ -112,7 +112,7 @@ const hasArtwork = computed(() => !!nowPlaying.value?.artwork)
           name="i-ph-pause-circle-duotone"
           class="w-4 h-4 shrink-0"
         />
-        <p>Aucune musique en cours.</p>
+        <p>No music playing.</p>
       </div>
     </UCard>
 


### PR DESCRIPTION
## Summary
- Update `app/components/home/live/NowPlaying.vue` to replace French fallback strings with English equivalents
- Change unknown artist fallback from `Artiste inconnu` to `Unknown artist`
- Change empty state message from `Aucune musique en cours.` to `No music playing.`

## Testing
- Not run - copy change only, no functional logic affected
- Verified diff renders correctly in `NowPlaying.vue` for artist fallback and empty state
- Manual check pending: view home live card with no active track and with track missing artist metadata