### PR TITLE
Gate non-owner Cloudflare previews and add PR preview comment

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -16,6 +16,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
+    # Push (main/master) always runs. For PRs:
+    # - if actor is repo owner, run directly
+    # - otherwise requires approval via Environment 'preview'
+    environment: ${{ github.event_name == 'pull_request' && github.actor != 'ArthurDanjou' && 'preview' || '' }}
+    concurrency:
+      group: cloudflare-${{ github.ref }}
+      cancel-in-progress: true
     
     steps:
       - name: Checkout
@@ -79,6 +86,22 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+      - name: Comment PR with preview URL
+        if: github.event_name == 'pull_request' && steps.wrangler.outputs.DEPLOY_URL != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloudflare-preview
+          message: |
+            🚀 **Preview deployed** — `${{ steps.target.outputs.env_name }}`
+
+            | | |
+            |---|---|
+            | **Branch** | `${{ github.head_ref }}` |
+            | **Commit** | `${{ github.sha }}` |
+            | **URL** | ${{ steps.wrangler.outputs.DEPLOY_URL }} |
+
+            _Deployed via Cloudflare Workers `wrangler ${{ steps.target.outputs.wrangler_command }}`._
 
       - name: Discord Notification
         uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## Summary
- Gate Cloudflare deploy for pull requests from non-owners behind `preview` environment approval (`ArthurDanjou` bypasses gate, pushes to `main`/`master` always run)
- Add concurrency `cloudflare-${{ github.ref }}` with `cancel-in-progress: true` to avoid overlapping deploys
- Post sticky PR comment with preview URL, branch, commit, and wrangler command when `wrangler` outputs `DEPLOY_URL`
- Translate Now Playing fallback strings to English (from commit history)

## Testing
- Not run: Cloudflare workflow approval gate requires a pull request from a non-owner/fork to verify `preview` environment gating
- Not run: Sticky preview URL comment requires a pull request deploy to verify `steps.wrangler.outputs.DEPLOY_URL` and `steps.target.outputs.env_name`
- Not run: Now Playing fallback translation — no diff in this patch, needs manual UI check with no track playing